### PR TITLE
Fix conflicting mobile sidebar toggle

### DIFF
--- a/static/js/naver-interactions.js
+++ b/static/js/naver-interactions.js
@@ -44,11 +44,12 @@ class NaverStyleUI {
         // 무한 스크롤
         $(window).on('scroll', this.handleInfiniteScroll);
 
-        // 모바일 사이드바 토글
-        $(document).on('click', '.navbar-toggler', function() {
-            $('#sidebar').toggleClass('show');
-            $('body').toggleClass('sidebar-open');
-        });
+        // 모바일 사이드바 토글은 custom.js에서 담당하므로
+        // 중복 이벤트 등록을 피하기 위해 기본 동작을 제거합니다.
+        // $(document).on('click', '.navbar-toggler', function() {
+        //     $('#sidebar').toggleClass('show');
+        //     $('body').toggleClass('sidebar-open');
+        // });
 
         // 사이드바 외부 클릭시 닫기
         $(document).on('click', function(e) {


### PR DESCRIPTION
## Summary
- remove duplicate navbar toggler handler in `naver-interactions.js`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6875ef7cf0b0832f8aae4436969609f2