### PR TITLE
Fix mobile sidebar overlay position

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -125,6 +125,8 @@ body {
         display: block;
         opacity: 1;
         pointer-events: auto;
+        left: 280px;
+        width: calc(100% - 280px);
     }
     
     /* 사이드바가 열렸을 때 body 스크롤 방지 */


### PR DESCRIPTION
## Summary
- make sidebar overlay leave space for the sidebar when opened so links remain clickable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687605adae1c832f89f8929a90611b7e