### PR TITLE
Adjust mobile sidebar to respect navbar height

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -20,6 +20,7 @@
     --shadow-light: 0 1px 3px rgba(0,0,0,0.1);
     --shadow-medium: 0 2px 8px rgba(0,0,0,0.15);
     --border-radius: 8px;
+    --navbar-height: 76px;
 }
 
 * {
@@ -76,7 +77,7 @@ body {
 /* 사이드바 */
 .sidebar {
     background-color: white;
-    min-height: calc(100vh - 76px);
+    min-height: calc(100vh - var(--navbar-height));
     box-shadow: var(--shadow-light);
     border-right: 1px solid var(--naver-gray-200);
     padding: 24px 0;
@@ -87,10 +88,10 @@ body {
 @media (max-width: 767.98px) {
     .sidebar {
         position: fixed;
-        top: 76px;
+        top: var(--navbar-height);
         left: 0;
         width: 280px;
-        height: calc(100vh - 76px);
+        height: calc(100vh - var(--navbar-height));
         z-index: 1060;
         transform: translateX(-100%);
         overflow-y: auto;
@@ -109,10 +110,10 @@ body {
     /* 모바일에서 사이드바가 열렸을 때 배경 오버레이 */
     .sidebar-overlay {
         position: fixed;
-        top: 76px;
+        top: var(--navbar-height);
         left: 0;
         width: 100%;
-        height: calc(100vh - 76px);
+        height: calc(100vh - var(--navbar-height));
         background-color: rgba(0, 0, 0, 0.5);
         z-index: 1050;
         display: none;
@@ -281,7 +282,7 @@ body {
 /* 메인 컨텐츠 */
 .main-content {
     background-color: var(--naver-gray-50);
-    min-height: calc(100vh - 76px);
+    min-height: calc(100vh - var(--navbar-height));
     padding: 24px;
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -317,6 +317,13 @@ $(document).ready(function() {
     const $body = $('body');
     const $toggleBtn = $('#sidebarToggle');
 
+    function setNavbarHeight() {
+        const height = $('.navbar').outerHeight() || 0;
+        document.documentElement.style.setProperty('--navbar-height', height + 'px');
+    }
+    setNavbarHeight();
+    $(window).on('resize load', setNavbarHeight);
+
     function openSidebar() {
         const scrollTop = $(window).scrollTop();
         $body.data('scroll-position', scrollTop);


### PR DESCRIPTION
## Summary
- add `--navbar-height` css variable
- use this variable for mobile sidebar and overlay positioning
- dynamically set navbar height in JS to avoid header overlap

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68760ffcfbfc832fa0bd2adeff848111