### PR TITLE
Fix iOS sidebar toggle

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -355,12 +355,17 @@ $(document).ready(function() {
         }
     }
 
-    // 모바일 환경에서도 제대로 동작하도록 click과 touchend 모두 처리
-    $('#sidebarToggle').on('click touchend', function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        toggleSidebar();
-    });
+    // iOS Safari에서 중복 이벤트가 발생하지 않도록 클릭과 터치를 분리
+    $('#sidebarToggle')
+        .on('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleSidebar();
+        })
+        .on('touchstart', function(e) {
+            // 터치 시작 시 기본 동작을 막아 300ms 지연을 방지
+            e.preventDefault();
+        });
 
     // 오버레이 영역도 터치 이벤트를 지원해 자연스럽게 닫히도록 수정
     $('#sidebarOverlay').on('click touchend', function(e) {


### PR DESCRIPTION
## Summary
- avoid double events on sidebar toggle button on iOS Safari by splitting click and touchstart handlers

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687993474300832f84026fd6ef9a8ce4