### PR TITLE
Refactor account templates

### DIFF
--- a/templates/accounts/user_create.html
+++ b/templates/accounts/user_create.html
@@ -1,508 +1,177 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .user-create-container {
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 20px;
-    }
-    
-    .form-section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .section-title {
-        color: #333;
-        font-size: 18px;
-        font-weight: 600;
-        margin-bottom: 20px;
-        padding-bottom: 10px;
-        border-bottom: 2px solid #03C75A;
-    }
-    
-    .form-row {
-        display: flex;
-        gap: 15px;
-        margin-bottom: 15px;
-    }
-    
-    .form-col {
-        flex: 1;
-    }
-    
-    .form-group {
-        margin-bottom: 20px;
-    }
-    
-    .form-label {
-        display: block;
-        margin-bottom: 8px;
-        font-weight: 500;
-        color: #333;
-        font-size: 14px;
-    }
-    
-    .required {
-        color: #e74c3c;
-    }
-    
-    .form-control {
-        width: 100%;
-        padding: 12px 16px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        font-size: 14px;
-        line-height: 1.5;
-        transition: all 0.3s ease;
-        background-color: #fff;
-    }
-    
-    .form-control:focus {
-        outline: none;
-        border-color: #03C75A;
-        box-shadow: 0 0 0 3px rgba(3, 199, 90, 0.1);
-        background-color: #fff;
-    }
-    
-    .form-control::placeholder {
-        color: #999;
-        opacity: 1;
-    }
-    
-    select.form-control {
-        cursor: pointer;
-    }
-    
-    textarea.form-control {
-        resize: vertical;
-        min-height: 100px;
-    }
-    
-    .checkbox-group {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 20px;
-        margin-top: 8px;
-    }
-    
-    .checkbox-item {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        padding: 8px 12px;
-        border: 1px solid #e9ecef;
-        border-radius: 6px;
-        transition: all 0.3s ease;
-        cursor: pointer;
-        min-width: 120px;
-    }
-    
-    .checkbox-item:hover {
-        border-color: #03C75A;
-        background-color: rgba(3, 199, 90, 0.05);
-    }
-    
-    .checkbox-item input[type="checkbox"] {
-        margin: 0;
-        width: 16px;
-        height: 16px;
-        cursor: pointer;
-    }
-    
-    .checkbox-item label {
-        margin: 0;
-        cursor: pointer;
-        font-size: 14px;
-        color: #333;
-    }
-    
-    .btn-group {
-        display: flex;
-        gap: 12px;
-        justify-content: flex-end;
-        margin-top: 40px;
-        padding-top: 20px;
-        border-top: 1px solid #e9ecef;
-    }
-    
-    .btn {
-        padding: 12px 24px;
-        border-radius: 8px;
-        font-weight: 500;
-        font-size: 14px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        border: none;
-        min-width: 120px;
-    }
-    
-    .btn-primary {
-        background: linear-gradient(135deg, #03C75A 0%, #029B47 100%);
-        color: white;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        color: white;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-        transform: translateY(-1px);
-    }
-        cursor: pointer;
-        transition: all 0.3s;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        border: none;
-        color: white;
-        padding: 12px 24px;
-        border-radius: 6px;
-        font-weight: 500;
-        cursor: pointer;
-        transition: all 0.3s;
-        text-decoration: none;
-        display: inline-block;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-    }
-    
-    .team-create-section {
-        background: #f8f9fa;
-        border: 1px dashed #03C75A;
-        border-radius: 8px;
-        padding: 15px;
-        margin-top: 10px;
-    }
-    
-    .team-create-toggle {
-        color: #03C75A;
-        cursor: pointer;
-        font-weight: 500;
-        text-decoration: none;
-    }
-    
-    .team-create-toggle:hover {
-        text-decoration: underline;
-    }
-    
-    .team-create-form {
-        display: none;
-        margin-top: 15px;
-    }
-    
-    .alert {
-        padding: 12px 16px;
-        border-radius: 6px;
-        margin-bottom: 20px;
-    }
-    
-    .alert-success {
-        background-color: #d4edda;
-        border: 1px solid #c3e6cb;
-        color: #155724;
-    }
-    
-    .alert-danger {
-        background-color: #f8d7da;
-        border: 1px solid #f5c6cb;
-        color: #721c24;
-    }
-    
-    @media (max-width: 768px) {
-        .form-row {
-            flex-direction: column;
-            gap: 0;
-        }
-        
-        .checkbox-group {
-            flex-direction: column;
-            gap: 10px;
-        }
-        
-        .btn-group {
-            flex-direction: column;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="user-create-container">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">{{ title }}</h2>
-        <a href="{% url 'user_list' %}" class="btn btn-secondary">
-            <i class="fas fa-arrow-left me-2"></i>목록으로
-        </a>
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="mb-0">
+                    <i class="fas fa-user-plus"></i> {{ title }}
+                </h4>
+            </div>
+            <div class="card-body">
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+
+                <form method="post" id="userCreateForm">
+                    {% csrf_token %}
+
+                    <div class="mb-4">
+                        <h5 class="mb-3"><i class="fas fa-user me-2"></i>기본 계정 정보</h5>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.username.id_for_label }}" class="form-label">사용자 ID</label>
+                                {{ form.username }}
+                                {% if form.username.errors %}
+                                    <div class="text-danger small">{{ form.username.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.email.id_for_label }}" class="form-label">이메일</label>
+                                {{ form.email }}
+                                {% if form.email.errors %}
+                                    <div class="text-danger small">{{ form.email.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.password1.id_for_label }}" class="form-label">비밀번호</label>
+                                {{ form.password1 }}
+                                {% if form.password1.errors %}
+                                    <div class="text-danger small">{{ form.password1.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.password2.id_for_label }}" class="form-label">비밀번호 확인</label>
+                                {{ form.password2 }}
+                                {% if form.password2.errors %}
+                                    <div class="text-danger small">{{ form.password2.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <h5 class="mb-3"><i class="fas fa-id-card me-2"></i>개인 정보</h5>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.last_name_ko.id_for_label }}" class="form-label">성 (한글)</label>
+                                {{ form.last_name_ko }}
+                                {% if form.last_name_ko.errors %}
+                                    <div class="text-danger small">{{ form.last_name_ko.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.first_name_ko.id_for_label }}" class="form-label">이름 (한글)</label>
+                                {{ form.first_name_ko }}
+                                {% if form.first_name_ko.errors %}
+                                    <div class="text-danger small">{{ form.first_name_ko.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.first_name.id_for_label }}" class="form-label">이름 (영문)</label>
+                                {{ form.first_name }}
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.last_name.id_for_label }}" class="form-label">성 (영문)</label>
+                                {{ form.last_name }}
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.position.id_for_label }}" class="form-label">직급</label>
+                                {{ form.position }}
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="{{ form.phone.id_for_label }}" class="form-label">전화번호</label>
+                                {{ form.phone }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <h5 class="mb-3"><i class="fas fa-shield-alt me-2"></i>권한 설정</h5>
+                        <div class="form-check mb-2">
+                            {{ form.is_staff }}
+                            <label class="form-check-label" for="{{ form.is_staff.id_for_label }}">관리자 권한</label>
+                        </div>
+                        <div class="form-check mb-2">
+                            {{ form.is_superuser }}
+                            <label class="form-check-label" for="{{ form.is_superuser.id_for_label }}">슈퍼유저 권한</label>
+                        </div>
+                        {% if form.groups.field.queryset %}
+                        <label class="form-label mt-3">권한 그룹</label>
+                        <div class="row">
+                            {% for group in form.groups.field.queryset %}
+                                <div class="col-md-4 mb-2">
+                                    <div class="form-check">
+                                        <input type="checkbox" name="groups" value="{{ group.id }}" id="group_{{ group.id }}" class="form-check-input">
+                                        <label class="form-check-label" for="group_{{ group.id }}">{{ group.name }}</label>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="mb-4">
+                        <h5 class="mb-3"><i class="fas fa-users me-2"></i>팀 설정</h5>
+                        {% if form.teams.field.queryset %}
+                        <label class="form-label">소속 팀</label>
+                        <div class="row">
+                            {% for team in form.teams.field.queryset %}
+                                <div class="col-md-4 mb-2">
+                                    <div class="form-check">
+                                        <input type="checkbox" name="teams" value="{{ team.id }}" id="team_{{ team.id }}" class="form-check-input">
+                                        <label class="form-check-label" for="team_{{ team.id }}">{{ team.name }}</label>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                        <div class="mb-3">
+                            <label for="{{ form.team_role.id_for_label }}" class="form-label">팀 내 역할</label>
+                            {{ form.team_role }}
+                        </div>
+                        <a href="#" class="btn btn-outline-secondary btn-sm" onclick="toggleTeamCreate(); return false;">
+                            <i class="fas fa-plus me-2"></i>새 팀 생성하기
+                        </a>
+                        <div id="teamCreateForm" class="mt-3" style="display:none;">
+                            <div class="row g-2">
+                                <div class="col">
+                                    <input type="text" class="form-control" id="newTeamName" placeholder="팀명을 입력하세요" required>
+                                </div>
+                                <div class="col-auto">
+                                    <button type="button" class="btn btn-primary" onclick="createTeam()">팀 생성</button>
+                                </div>
+                            </div>
+                            <textarea class="form-control mt-2" id="newTeamDescription" placeholder="팀 설명 (선택사항)" rows="2"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="d-flex justify-content-between">
+                        <a href="{% url 'user_list' %}" class="btn btn-secondary">
+                            <i class="fas fa-arrow-left"></i> 취소
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> 사용자 생성
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
-
-    {% if messages %}
-        {% for message in messages %}
-            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-        {% endfor %}
-    {% endif %}
-
-    <form method="post" id="userCreateForm">
-        {% csrf_token %}
-        
-        <!-- 기본 계정 정보 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-user me-2"></i>기본 계정 정보
-            </h3>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.username.id_for_label }}">
-                            사용자 ID <span class="required">*</span>
-                        </label>
-                        {{ form.username }}
-                        {% if form.username.errors %}
-                            <div class="text-danger small mt-1">{{ form.username.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.email.id_for_label }}">
-                            이메일 <span class="required">*</span>
-                        </label>
-                        {{ form.email }}
-                        {% if form.email.errors %}
-                            <div class="text-danger small mt-1">{{ form.email.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.password1.id_for_label }}">
-                            비밀번호 <span class="required">*</span>
-                        </label>
-                        {{ form.password1 }}
-                        {% if form.password1.errors %}
-                            <div class="text-danger small mt-1">{{ form.password1.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.password2.id_for_label }}">
-                            비밀번호 확인 <span class="required">*</span>
-                        </label>
-                        {{ form.password2 }}
-                        {% if form.password2.errors %}
-                            <div class="text-danger small mt-1">{{ form.password2.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- 개인 정보 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-id-card me-2"></i>개인 정보
-            </h3>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.last_name_ko.id_for_label }}">
-                            성 (한글) <span class="required">*</span>
-                        </label>
-                        {{ form.last_name_ko }}
-                        {% if form.last_name_ko.errors %}
-                            <div class="text-danger small mt-1">{{ form.last_name_ko.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.first_name_ko.id_for_label }}">
-                            이름 (한글) <span class="required">*</span>
-                        </label>
-                        {{ form.first_name_ko }}
-                        {% if form.first_name_ko.errors %}
-                            <div class="text-danger small mt-1">{{ form.first_name_ko.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.first_name.id_for_label }}">
-                            이름 (영문)
-                        </label>
-                        {{ form.first_name }}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.last_name.id_for_label }}">
-                            성 (영문)
-                        </label>
-                        {{ form.last_name }}
-                    </div>
-                </div>
-            </div>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.position.id_for_label }}">
-                            직급
-                        </label>
-                        {{ form.position }}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.phone.id_for_label }}">
-                            전화번호
-                        </label>
-                        {{ form.phone }}
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- 권한 설정 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-shield-alt me-2"></i>권한 설정
-            </h3>
-            
-            <div class="form-group">
-                <label class="form-label">시스템 권한</label>
-                <div class="checkbox-group">
-                    <div class="checkbox-item">
-                        {{ form.is_staff }}
-                        <label for="{{ form.is_staff.id_for_label }}">관리자 권한</label>
-                    </div>
-                    <div class="checkbox-item">
-                        {{ form.is_superuser }}
-                        <label for="{{ form.is_superuser.id_for_label }}">슈퍼유저 권한</label>
-                    </div>
-                </div>
-            </div>
-            
-            {% if form.groups.field.queryset %}
-            <div class="form-group">
-                <label class="form-label">권한 그룹</label>
-                <div class="checkbox-group">
-                    {% for group in form.groups.field.queryset %}
-                    <div class="checkbox-item">
-                        <input type="checkbox" name="groups" value="{{ group.id }}" 
-                               id="group_{{ group.id }}" class="form-check-input">
-                        <label for="group_{{ group.id }}">{{ group.name }}</label>
-                    </div>
-                    {% endfor %}
-                </div>
-            </div>
-            {% endif %}
-        </div>
-
-        <!-- 팀 설정 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-users me-2"></i>팀 설정
-            </h3>
-            
-            {% if form.teams.field.queryset %}
-            <div class="form-group">
-                <label class="form-label">소속 팀</label>
-                <div class="checkbox-group">
-                    {% for team in form.teams.field.queryset %}
-                    <div class="checkbox-item">
-                        <input type="checkbox" name="teams" value="{{ team.id }}" 
-                               id="team_{{ team.id }}" class="form-check-input">
-                        <label for="team_{{ team.id }}">{{ team.name }}</label>
-                    </div>
-                    {% endfor %}
-                </div>
-            </div>
-            {% endif %}
-            
-            <div class="form-group">
-                <label class="form-label" for="{{ form.team_role.id_for_label }}">
-                    팀 내 역할
-                </label>
-                {{ form.team_role }}
-            </div>
-            
-            <!-- 새 팀 생성 -->
-            <div class="team-create-section">
-                <a href="#" class="team-create-toggle" onclick="toggleTeamCreate()">
-                    <i class="fas fa-plus me-2"></i>새 팀 생성하기
-                </a>
-                <div class="team-create-form" id="teamCreateForm">
-                    <div class="form-row">
-                        <div class="form-col">
-                            <input type="text" class="form-control" id="newTeamName" 
-                                   placeholder="팀명을 입력하세요" required>
-                        </div>
-                        <div class="form-col">
-                            <button type="button" class="btn btn-primary" onclick="createTeam()">
-                                팀 생성
-                            </button>
-                        </div>
-                    </div>
-                    <div class="form-group mt-2">
-                        <textarea class="form-control" id="newTeamDescription" 
-                                  placeholder="팀 설명 (선택사항)" rows="2"></textarea>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="btn-group">
-            <a href="{% url 'user_list' %}" class="btn btn-secondary">취소</a>
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-2"></i>사용자 생성
-            </button>
-        </div>
-    </form>
 </div>
 {% endblock %}
 
@@ -510,22 +179,16 @@
 <script>
 function toggleTeamCreate() {
     const form = document.getElementById('teamCreateForm');
-    if (form.style.display === 'none' || form.style.display === '') {
-        form.style.display = 'block';
-    } else {
-        form.style.display = 'none';
-    }
+    form.style.display = form.style.display === 'none' || form.style.display === '' ? 'block' : 'none';
 }
 
 function createTeam() {
     const name = document.getElementById('newTeamName').value.trim();
     const description = document.getElementById('newTeamDescription').value.trim();
-    
     if (!name) {
         alert('팀명을 입력해주세요.');
         return;
     }
-    
     fetch('{% url "team_create_ajax" %}', {
         method: 'POST',
         headers: {
@@ -537,22 +200,14 @@ function createTeam() {
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            // 새 팀을 체크박스 목록에 추가
-            const checkboxGroup = document.querySelector('.checkbox-group');
-            const newCheckbox = document.createElement('div');
-            newCheckbox.className = 'checkbox-item';
-            newCheckbox.innerHTML = `
-                <input type="checkbox" name="teams" value="${data.team_id}" 
-                       id="team_${data.team_id}" class="form-check-input" checked>
-                <label for="team_${data.team_id}">${data.team_name}</label>
-            `;
-            checkboxGroup.appendChild(newCheckbox);
-            
-            // 폼 초기화 및 숨기기
+            const group = document.querySelector('#teamCreateForm').previousElementSibling;
+            const wrapper = document.createElement('div');
+            wrapper.className = 'col-md-4 mb-2';
+            wrapper.innerHTML = `<div class="form-check"><input type="checkbox" name="teams" value="${data.team_id}" id="team_${data.team_id}" class="form-check-input" checked><label class="form-check-label" for="team_${data.team_id}">${data.team_name}</label></div>`;
+            group.appendChild(wrapper);
             document.getElementById('newTeamName').value = '';
             document.getElementById('newTeamDescription').value = '';
             document.getElementById('teamCreateForm').style.display = 'none';
-            
             alert(data.message);
         } else {
             alert('팀 생성에 실패했습니다: ' + JSON.stringify(data.errors));

--- a/templates/accounts/user_delete.html
+++ b/templates/accounts/user_delete.html
@@ -1,272 +1,44 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .delete-container {
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-    }
-    
-    .delete-card {
-        background: white;
-        border-radius: 12px;
-        padding: 30px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        text-align: center;
-    }
-    
-    .delete-icon {
-        width: 80px;
-        height: 80px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #dc3545, #c82333);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin: 0 auto 20px;
-        color: white;
-        font-size: 32px;
-    }
-    
-    .delete-title {
-        color: #dc3545;
-        font-size: 24px;
-        font-weight: 600;
-        margin-bottom: 15px;
-    }
-    
-    .delete-message {
-        color: #666;
-        font-size: 16px;
-        line-height: 1.6;
-        margin-bottom: 30px;
-    }
-    
-    .user-info {
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 8px;
-        padding: 20px;
-        margin: 20px 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 15px;
-    }
-    
-    .user-avatar {
-        width: 50px;
-        height: 50px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #03C75A, #029B47);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-size: 20px;
-        font-weight: bold;
-    }
-    
-    .user-details h5 {
-        margin: 0;
-        color: #333;
-        font-weight: 600;
-    }
-    
-    .user-details p {
-        margin: 5px 0 0;
-        color: #666;
-        font-size: 14px;
-    }
-    
-    .warning-list {
-        background: #fff3cd;
-        border: 1px solid #ffeaa7;
-        border-radius: 8px;
-        padding: 20px;
-        margin: 20px 0;
-        text-align: left;
-    }
-    
-    .warning-list h6 {
-        color: #856404;
-        font-weight: 600;
-        margin-bottom: 10px;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
-    
-    .warning-list ul {
-        margin: 0;
-        padding-left: 20px;
-        color: #856404;
-    }
-    
-    .warning-list li {
-        margin-bottom: 5px;
-    }
-    
-    .btn-group {
-        display: flex;
-        gap: 15px;
-        justify-content: center;
-        margin-top: 30px;
-    }
-    
-    .btn {
-        padding: 12px 24px;
-        border-radius: 8px;
-        font-weight: 500;
-        font-size: 14px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        border: none;
-        min-width: 120px;
-        line-height: 1;
-    }
-    
-    .btn-danger {
-        background: linear-gradient(135deg, #dc3545, #c82333);
-        color: white;
-    }
-    
-    .btn-danger:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(220, 53, 69, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        color: white;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-        transform: translateY(-1px);
-    }
-    
-    @media (max-width: 768px) {
-        .user-info {
-            flex-direction: column;
-            text-align: center;
-        }
-        
-        .user-avatar {
-            margin-bottom: 10px;
-        }
-        
-        .btn-group {
-            flex-direction: column;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="delete-container">
-    <div class="delete-card">
-        <div class="delete-icon">
-            <i class="fas fa-exclamation-triangle"></i>
-        </div>
-        
-        <h2 class="delete-title">사용자 삭제 확인</h2>
-        
-        <p class="delete-message">
-            정말로 이 사용자를 삭제하시겠습니까?<br>
-            <strong>이 작업은 되돌릴 수 없습니다.</strong>
-        </p>
-        
-        <!-- 사용자 정보 -->
-        <div class="user-info">
-            <div class="user-avatar">
-                {% if user.profile %}
-                    {{ user.profile.get_korean_name|first|upper }}
-                {% else %}
-                    {{ user.username|first|upper }}
-                {% endif %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card text-center">
+            <div class="card-header bg-danger text-white">
+                <h4 class="mb-0"><i class="fas fa-exclamation-triangle"></i> 사용자 삭제 확인</h4>
             </div>
-            <div class="user-details">
-                <h5>
-                    {% if user.profile %}
-                        {{ user.profile.display_name }}
-                    {% else %}
-                        {{ user.username }}
-                    {% endif %}
-                </h5>
-                <p>{{ user.email }}</p>
-                {% if user.profile.primary_team %}
-                    <p>{{ user.profile.primary_team.name }}{% if user.profile.position %} · {{ user.profile.position }}{% endif %}</p>
-                {% endif %}
+            <div class="card-body">
+                <p class="mb-4">정말로 이 사용자를 삭제하시겠습니까?<br><strong>이 작업은 되돌릴 수 없습니다.</strong></p>
+                <div class="mb-4">
+                    <div class="d-flex justify-content-center align-items-center mb-2">
+                        <div class="rounded-circle bg-success text-white d-flex align-items-center justify-content-center me-2" style="width:50px;height:50px;">
+                            {% if user.profile %}{{ user.profile.get_korean_name|first|upper }}{% else %}{{ user.username|first|upper }}{% endif %}
+                        </div>
+                        <div>
+                            <div>{{ user.profile.display_name if user.profile else user.username }}</div>
+                            <small class="text-muted">{{ user.email }}</small>
+                        </div>
+                    </div>
+                </div>
+                <form method="post" id="deleteForm" class="d-inline">
+                    {% csrf_token %}
+                    <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary me-2"><i class="fas fa-times"></i> 취소</a>
+                    <button type="submit" class="btn btn-danger" id="confirmDelete"><i class="fas fa-trash"></i> 삭제 확인</button>
+                </form>
             </div>
         </div>
-        
-        <!-- 경고 메시지 -->
-        <div class="warning-list">
-            <h6>
-                <i class="fas fa-exclamation-circle"></i>
-                삭제 시 다음 데이터도 함께 삭제됩니다:
-            </h6>
-            <ul>
-                <li>사용자 프로필 정보</li>
-                <li>작성한 모든 업무 및 댓글</li>
-                <li>업로드한 파일들</li>
-                <li>워크로그 기록</li>
-                <li>팀 멤버십 정보</li>
-                <li>알림 및 활동 기록</li>
-            </ul>
-        </div>
-        
-        <form method="post" id="deleteForm">
-            {% csrf_token %}
-            <div class="btn-group">
-                <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary">
-                    <i class="fas fa-times me-2"></i>취소
-                </a>
-                <button type="submit" class="btn btn-danger" id="confirmDelete">
-                    <i class="fas fa-trash me-2"></i>삭제 확인
-                </button>
-            </div>
-        </form>
     </div>
 </div>
 {% endblock %}
 
 {% block extra_js %}
 <script>
-// 삭제 확인 처리
-document.getElementById('deleteForm').addEventListener('submit', function(e) {
-    e.preventDefault();
-    
-    const userName = '{% if user.profile %}{{ user.profile.display_name }}{% else %}{{ user.username }}{% endif %}';
-    
-    if (confirm(`정말로 "${userName}" 사용자를 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없으며, 관련된 모든 데이터가 함께 삭제됩니다.`)) {
-        // 두 번째 확인
-        if (confirm('마지막 확인입니다. 정말로 삭제하시겠습니까?')) {
-            this.submit();
-        }
+document.getElementById('deleteForm').addEventListener('submit', function(e){
+    if(!confirm('정말로 삭제하시겠습니까?')){
+        e.preventDefault();
     }
-});
-
-// 삭제 버튼 호버 효과
-document.getElementById('confirmDelete').addEventListener('mouseenter', function() {
-    this.innerHTML = '<i class="fas fa-trash me-2"></i>영구 삭제';
-});
-
-document.getElementById('confirmDelete').addEventListener('mouseleave', function() {
-    this.innerHTML = '<i class="fas fa-trash me-2"></i>삭제 확인';
 });
 </script>
 {% endblock %}

--- a/templates/accounts/user_detail.html
+++ b/templates/accounts/user_detail.html
@@ -1,428 +1,107 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .user-detail-container {
-        max-width: 1000px;
-        margin: 0 auto;
-        padding: 20px;
-    }
-    
-    .profile-header {
-        background: white;
-        border-radius: 12px;
-        padding: 30px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        text-align: center;
-    }
-    
-    .profile-avatar {
-        width: 80px;
-        height: 80px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #03C75A, #029B47);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-size: 32px;
-        font-weight: bold;
-        margin: 0 auto 20px;
-    }
-    
-    .profile-name {
-        font-size: 24px;
-        font-weight: 600;
-        color: #333;
-        margin-bottom: 5px;
-    }
-    
-    .profile-email {
-        color: #666;
-        margin-bottom: 15px;
-    }
-    
-    .profile-badges {
-        display: flex;
-        justify-content: center;
-        gap: 8px;
-        flex-wrap: wrap;
-    }
-    
-    .info-section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .section-title {
-        color: #333;
-        font-size: 18px;
-        font-weight: 600;
-        margin-bottom: 20px;
-        padding-bottom: 10px;
-        border-bottom: 2px solid #03C75A;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-    }
-    
-    .info-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 20px;
-    }
-    
-    .info-item {
-        display: flex;
-        flex-direction: column;
-    }
-    
-    .info-label {
-        font-weight: 500;
-        color: #666;
-        font-size: 14px;
-        margin-bottom: 5px;
-    }
-    
-    .info-value {
-        color: #333;
-        font-size: 16px;
-    }
-    
-    .badge {
-        padding: 6px 12px;
-        border-radius: 12px;
-        font-size: 12px;
-        font-weight: 500;
-        margin-right: 6px;
-        margin-bottom: 6px;
-        display: inline-block;
-    }
-    
-    .badge-success {
-        background-color: #d4edda;
-        color: #155724;
-    }
-    
-    .badge-warning {
-        background-color: #fff3cd;
-        color: #856404;
-    }
-    
-    .badge-info {
-        background-color: #d1ecf1;
-        color: #0c5460;
-    }
-    
-    .badge-secondary {
-        background-color: #e2e3e5;
-        color: #383d41;
-    }
-    
-    .team-card {
-        border: 1px solid #eee;
-        border-radius: 8px;
-        padding: 15px;
-        margin-bottom: 10px;
-        transition: all 0.3s;
-    }
-    
-    .team-card:hover {
-        border-color: #03C75A;
-        box-shadow: 0 2px 8px rgba(3, 199, 90, 0.1);
-    }
-    
-    .team-name {
-        font-weight: 600;
-        color: #333;
-        margin-bottom: 5px;
-    }
-    
-    .team-role {
-        font-size: 14px;
-        color: #666;
-    }
-    
-    .team-joined {
-        font-size: 12px;
-        color: #999;
-        margin-top: 5px;
-    }
-    
-    .btn-group {
-        display: flex;
-        gap: 10px;
-        justify-content: flex-end;
-        margin-top: 30px;
-    }
-    
-    .btn {
-        padding: 10px 20px;
-        border-radius: 6px;
-        font-weight: 500;
-        cursor: pointer;
-        transition: all 0.3s;
-        text-decoration: none;
-        display: inline-block;
-        border: none;
-    }
-    
-    .btn-primary {
-        background: linear-gradient(135deg, #03C75A 0%, #029B47 100%);
-        color: white;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        color: white;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-info {
-        background: #17a2b8;
-        color: white;
-    }
-    
-    .btn-info:hover {
-        background: #138496;
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-danger {
-        background: #dc3545;
-        color: white;
-    }
-    
-    .btn-danger:hover {
-        background: #c82333;
-        color: white;
-        text-decoration: none;
-    }
-    
-    .empty-state {
-        text-align: center;
-        padding: 40px 20px;
-        color: #666;
-    }
-    
-    .empty-state i {
-        font-size: 32px;
-        color: #ddd;
-        margin-bottom: 15px;
-    }
-    
-    @media (max-width: 768px) {
-        .info-grid {
-            grid-template-columns: 1fr;
-        }
-        
-        .btn-group {
-            flex-direction: column;
-        }
-        
-        .profile-badges {
-            justify-content: center;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="user-detail-container">
-    <!-- 프로필 헤더 -->
-    <div class="profile-header">
-        <div class="profile-avatar">
-            {{ profile.get_korean_name|first|upper }}
-        </div>
-        <h1 class="profile-name">{{ profile.display_name }}</h1>
-        <div class="profile-email">{{ user.email }}</div>
-        <div class="profile-badges">
-            {% if user.is_superuser %}
-                <span class="badge badge-warning">슈퍼유저</span>
-            {% elif user.is_staff %}
-                <span class="badge badge-success">관리자</span>
-            {% else %}
-                <span class="badge badge-secondary">일반사용자</span>
-            {% endif %}
-            
-            {% for group in user.groups.all %}
-                <span class="badge badge-info">{{ group.name }}</span>
-            {% endfor %}
-        </div>
-    </div>
-
-    <!-- 기본 정보 -->
-    <div class="info-section">
-        <h3 class="section-title">
-            <i class="fas fa-id-card"></i>
-            기본 정보
-        </h3>
-        <div class="info-grid">
-            <div class="info-item">
-                <span class="info-label">사용자 ID</span>
-                <span class="info-value">{{ user.username }}</span>
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card mb-4">
+            <div class="card-header text-center">
+                <h4 class="mb-0"><i class="fas fa-user"></i> {{ profile.display_name }}</h4>
             </div>
-            <div class="info-item">
-                <span class="info-label">이메일</span>
-                <span class="info-value">{{ user.email|default:"-" }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">한글 이름</span>
-                <span class="info-value">{{ profile.get_korean_name|default:"-" }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">영문 이름</span>
-                <span class="info-value">
-                    {% if user.first_name or user.last_name %}
-                        {{ user.first_name }} {{ user.last_name }}
-                    {% else %}
-                        -
-                    {% endif %}
-                </span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">주요 팀</span>
-                <span class="info-value">{{ profile.primary_team.name|default:"-" }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">직급</span>
-                <span class="info-value">{{ profile.position|default:"-" }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">전화번호</span>
-                <span class="info-value">{{ profile.phone|default:"-" }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">가입일</span>
-                <span class="info-value">{{ user.date_joined|date:"Y년 m월 d일" }}</span>
-            </div>
-        </div>
-    </div>
-
-    <!-- 소속 팀 정보 -->
-    <div class="info-section">
-        <h3 class="section-title">
-            <i class="fas fa-users"></i>
-            소속 팀 ({{ team_memberships.count }}개)
-        </h3>
-        
-        {% if team_memberships %}
-            {% for membership in team_memberships %}
-            <div class="team-card">
-                <div class="team-name">{{ membership.team.name }}</div>
-                <div class="team-role">
-                    역할: 
-                    {% if membership.role == 'leader' %}
-                        <span class="badge badge-warning">팀장</span>
-                    {% elif membership.role == 'admin' %}
-                        <span class="badge badge-success">관리자</span>
-                    {% else %}
-                        <span class="badge badge-info">멤버</span>
-                    {% endif %}
+            <div class="card-body">
+                <div class="text-center mb-4">
+                    <div class="rounded-circle bg-success text-white d-inline-flex align-items-center justify-content-center" style="width:80px;height:80px;font-size:32px;">
+                        {{ profile.get_korean_name|first|upper }}
+                    </div>
+                    <p class="mt-2 mb-0">{{ user.email }}</p>
                 </div>
-                {% if membership.team.description %}
-                <div class="text-muted small mt-2">{{ membership.team.description }}</div>
-                {% endif %}
-                <div class="team-joined">{{ membership.joined_at|date:"Y년 m월 d일" }} 가입</div>
-            </div>
-            {% endfor %}
-        {% else %}
-            <div class="empty-state">
-                <i class="fas fa-users"></i>
-                <p>소속된 팀이 없습니다.</p>
-            </div>
-        {% endif %}
-    </div>
 
-    <!-- 권한 정보 -->
-    <div class="info-section">
-        <h3 class="section-title">
-            <i class="fas fa-shield-alt"></i>
-            권한 정보
-        </h3>
-        <div class="info-grid">
-            <div class="info-item">
-                <span class="info-label">시스템 권한</span>
-                <div class="info-value">
+                <h5 class="mb-3">기본 정보</h5>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">사용자 ID</div>
+                    <div class="col-sm-8">{{ user.username }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">한글 이름</div>
+                    <div class="col-sm-8">{{ profile.get_korean_name|default:"-" }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">영문 이름</div>
+                    <div class="col-sm-8">
+                        {% if user.first_name or user.last_name %}
+                            {{ user.first_name }} {{ user.last_name }}
+                        {% else %}-{% endif %}
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">직급</div>
+                    <div class="col-sm-8">{{ profile.position|default:"-" }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">전화번호</div>
+                    <div class="col-sm-8">{{ profile.phone|default:"-" }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-sm-4 text-muted">가입일</div>
+                    <div class="col-sm-8">{{ user.date_joined|date:"Y년 m월 d일" }}</div>
+                </div>
+
+                <h5 class="mt-4 mb-3">권한 정보</h5>
+                <div class="mb-2">
                     {% if user.is_superuser %}
-                        <span class="badge badge-warning">슈퍼유저</span>
+                        <span class="badge bg-warning text-dark">슈퍼유저</span>
                     {% elif user.is_staff %}
-                        <span class="badge badge-success">관리자</span>
+                        <span class="badge bg-success">관리자</span>
                     {% else %}
-                        <span class="badge badge-secondary">일반사용자</span>
+                        <span class="badge bg-secondary">일반사용자</span>
                     {% endif %}
                 </div>
-            </div>
-            <div class="info-item">
-                <span class="info-label">권한 그룹</span>
-                <div class="info-value">
+                <div>
                     {% for group in user.groups.all %}
-                        <span class="badge badge-info">{{ group.name }}</span>
+                        <span class="badge bg-info text-dark">{{ group.name }}</span>
                     {% empty %}
-                        <span class="text-muted">-</span>
+                        <span class="text-muted">권한 그룹 없음</span>
                     {% endfor %}
                 </div>
             </div>
-            <div class="info-item">
-                <span class="info-label">계정 상태</span>
-                <div class="info-value">
-                    {% if user.is_active %}
-                        <span class="badge badge-success">활성</span>
-                    {% else %}
-                        <span class="badge badge-secondary">비활성</span>
-                    {% endif %}
-                </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="fas fa-users"></i> 소속 팀 ({{ team_memberships.count }})</h5>
             </div>
-            <div class="info-item">
-                <span class="info-label">최근 로그인</span>
-                <span class="info-value">
-                    {% if user.last_login %}
-                        {{ user.last_login|date:"Y년 m월 d일 H:i" }}
-                    {% else %}
-                        로그인 기록 없음
-                    {% endif %}
-                </span>
+            <div class="card-body">
+                {% if team_memberships %}
+                    {% for membership in team_memberships %}
+                        <div class="mb-2">
+                            <strong>{{ membership.team.name }}</strong>
+                            {% if membership.role == 'leader' %}
+                                <span class="badge bg-warning text-dark">팀장</span>
+                            {% elif membership.role == 'admin' %}
+                                <span class="badge bg-success">관리자</span>
+                            {% else %}
+                                <span class="badge bg-info text-dark">멤버</span>
+                            {% endif %}
+                            <div class="text-muted small">{{ membership.joined_at|date:"Y년 m월 d일" }} 가입</div>
+                        </div>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-center text-muted mb-0">소속된 팀이 없습니다.</p>
+                {% endif %}
             </div>
         </div>
-    </div>
 
-    <!-- 작업 버튼 -->
-    <div class="btn-group">
-        <a href="{% url 'user_list' %}" class="btn btn-secondary">
-            <i class="fas fa-arrow-left me-2"></i>목록으로
-        </a>
-        <a href="{% url 'user_edit' user.id %}" class="btn btn-primary">
-            <i class="fas fa-edit me-2"></i>정보 수정
-        </a>
-        <a href="{% url 'user_team_manage' user.id %}" class="btn btn-info">
-            <i class="fas fa-users me-2"></i>팀 관리
-        </a>
-        {% if user != request.user %}
-        <a href="{% url 'user_delete' user.id %}" class="btn btn-danger"
-           onclick="return confirm('정말로 이 사용자를 삭제하시겠습니까?')">
-            <i class="fas fa-trash me-2"></i>사용자 삭제
-        </a>
-        {% endif %}
+        <div class="d-flex justify-content-between">
+            <a href="{% url 'user_list' %}" class="btn btn-secondary"><i class="fas fa-arrow-left"></i> 목록으로</a>
+            <div>
+                <a href="{% url 'user_team_manage' user.id %}" class="btn btn-info me-2"><i class="fas fa-users"></i> 팀 관리</a>
+                <a href="{% url 'user_edit' user.id %}" class="btn btn-primary me-2"><i class="fas fa-edit"></i> 정보 수정</a>
+                {% if user != request.user %}
+                <a href="{% url 'user_delete' user.id %}" class="btn btn-danger" onclick="return confirm('정말로 이 사용자를 삭제하시겠습니까?')"><i class="fas fa-trash"></i> 삭제</a>
+                {% endif %}
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/accounts/user_edit.html
+++ b/templates/accounts/user_edit.html
@@ -1,627 +1,124 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .user-edit-container {
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 20px;
-    }
-    
-    .form-section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .section-title {
-        color: #333;
-        font-size: 18px;
-        font-weight: 600;
-        margin-bottom: 20px;
-        padding-bottom: 10px;
-        border-bottom: 2px solid #03C75A;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-    }
-    
-    .form-row {
-        display: flex;
-        gap: 15px;
-        margin-bottom: 15px;
-    }
-    
-    .form-col {
-        flex: 1;
-    }
-    
-    .form-group {
-        margin-bottom: 20px;
-    }
-    
-    .form-label {
-        display: block;
-        margin-bottom: 8px;
-        font-weight: 500;
-        color: #333;
-        font-size: 14px;
-    }
-    
-    .required {
-        color: #e74c3c;
-    }
-    
-    .form-control {
-        width: 100%;
-        padding: 12px 16px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        font-size: 14px;
-        line-height: 1.5;
-        transition: all 0.3s ease;
-        background-color: #fff;
-    }
-    
-    .form-control:focus {
-        outline: none;
-        border-color: #03C75A;
-        box-shadow: 0 0 0 3px rgba(3, 199, 90, 0.1);
-        background-color: #fff;
-    }
-    
-    .form-control::placeholder {
-        color: #999;
-        opacity: 1;
-    }
-    
-    select.form-control {
-        cursor: pointer;
-    }
-    
-    .checkbox-group {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 20px;
-        margin-top: 8px;
-    }
-    
-    .checkbox-item {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        padding: 8px 12px;
-        border: 1px solid #e9ecef;
-        border-radius: 6px;
-        transition: all 0.3s ease;
-        cursor: pointer;
-        min-width: 120px;
-    }
-    
-    .checkbox-item:hover {
-        border-color: #03C75A;
-        background-color: rgba(3, 199, 90, 0.05);
-    }
-    
-    .checkbox-item input[type="checkbox"] {
-        margin: 0;
-        width: 16px;
-        height: 16px;
-        cursor: pointer;
-    }
-    
-    .checkbox-item label {
-        margin: 0;
-        cursor: pointer;
-        font-size: 14px;
-        color: #333;
-    }
-    
-    .btn-group {
-        display: flex;
-        gap: 12px;
-        justify-content: flex-end;
-        margin-top: 40px;
-        padding-top: 20px;
-        border-top: 1px solid #e9ecef;
-    }
-    
-    .btn {
-        padding: 12px 24px;
-        border-radius: 8px;
-        font-weight: 500;
-        font-size: 14px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        border: none;
-        min-width: 120px;
-        line-height: 1;
-    }
-    
-    .btn-primary {
-        background: linear-gradient(135deg, #03C75A 0%, #029B47 100%);
-        color: white;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        color: white;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-        transform: translateY(-1px);
-    }
-    
-    .alert {
-        padding: 12px 16px;
-        border-radius: 6px;
-        margin-bottom: 20px;
-    }
-    
-    .alert-success {
-        background-color: #d4edda;
-        border: 1px solid #c3e6cb;
-        color: #155724;
-    }
-    
-    .alert-danger {
-        background-color: #f8d7da;
-        border: 1px solid #f5c6cb;
-        color: #721c24;
-    }
-    
-    .user-info-card {
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 8px;
-        padding: 20px;
-        margin-bottom: 20px;
-    }
-    
-    .user-avatar {
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #03C75A, #029B47);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-size: 24px;
-        font-weight: bold;
-        margin-right: 15px;
-    }
-    
-    .user-details h4 {
-        margin: 0;
-        color: #333;
-        font-weight: 600;
-    }
-    
-    .user-details p {
-        margin: 5px 0 0;
-        color: #666;
-    }
-    
-    .help-text {
-        font-size: 12px;
-        color: #666;
-        margin-top: 6px;
-        line-height: 1.4;
-    }
-    
-    .team-create-section {
-        background: #f8f9fa;
-        border: 1px dashed #03C75A;
-        border-radius: 8px;
-        padding: 15px;
-        margin-top: 10px;
-    }
-    
-    .team-create-toggle {
-        color: #03C75A;
-        cursor: pointer;
-        font-weight: 500;
-        text-decoration: none;
-    }
-    
-    .team-create-toggle:hover {
-        text-decoration: underline;
-    }
-    
-    .team-create-form {
-        display: none;
-        margin-top: 15px;
-    }
-    
-    @media (max-width: 768px) {
-        .form-row {
-            flex-direction: column;
-            gap: 0;
-        }
-        
-        .checkbox-group {
-            flex-direction: column;
-            gap: 10px;
-        }
-        
-        .btn-group {
-            flex-direction: column;
-        }
-        
-        .user-info-card {
-            text-align: center;
-        }
-        
-        .user-info-card .d-flex {
-            flex-direction: column;
-            align-items: center;
-        }
-        
-        .user-avatar {
-            margin-right: 0;
-            margin-bottom: 15px;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="user-edit-container">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">{{ title }}</h2>
-        <div class="d-flex gap-2">
-            <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary">
-                <i class="fas fa-eye me-2"></i>상세보기
-            </a>
-            <a href="{% url 'user_list' %}" class="btn btn-secondary">
-                <i class="fas fa-arrow-left me-2"></i>목록으로
-            </a>
-        </div>
-    </div>
-
-    {% if messages %}
-        {% for message in messages %}
-            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="mb-0"><i class="fas fa-user-edit"></i> {{ title }}</h4>
             </div>
-        {% endfor %}
-    {% endif %}
-
-    <!-- 사용자 정보 카드 -->
-    <div class="user-info-card">
-        <div class="d-flex align-items-center">
-            <div class="user-avatar">
-                {{ profile.get_korean_name|first|upper }}
-            </div>
-            <div class="user-details">
-                <h4>{{ profile.display_name }}</h4>
-                <p>{{ user.email }}</p>
-                <p class="text-muted small">가입일: {{ user.date_joined|date:"Y년 m월 d일" }}</p>
-            </div>
-        </div>
-    </div>
-
-    <form method="post" id="userEditForm">
-        {% csrf_token %}
-        
-        <!-- 기본 정보 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-user"></i>
-                기본 정보
-            </h3>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ user_form.first_name.id_for_label }}">
-                            이름 (영문)
-                        </label>
-                        {{ user_form.first_name }}
-                        {% if user_form.first_name.errors %}
-                            <div class="text-danger small mt-1">{{ user_form.first_name.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ user_form.last_name.id_for_label }}">
-                            성 (영문)
-                        </label>
-                        {{ user_form.last_name }}
-                        {% if user_form.last_name.errors %}
-                            <div class="text-danger small mt-1">{{ user_form.last_name.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            
-            <div class="form-group">
-                <label class="form-label" for="{{ user_form.email.id_for_label }}">
-                    이메일 <span class="required">*</span>
-                </label>
-                {{ user_form.email }}
-                {% if user_form.email.errors %}
-                    <div class="text-danger small mt-1">{{ user_form.email.errors.0 }}</div>
+            <div class="card-body">
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endfor %}
                 {% endif %}
-            </div>
-        </div>
 
-        <!-- 프로필 정보 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-id-card"></i>
-                프로필 정보
-            </h3>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.last_name_ko.id_for_label }}">
-                            성 (한글)
-                        </label>
-                        {{ form.last_name_ko }}
-                        {% if form.last_name_ko.errors %}
-                            <div class="text-danger small mt-1">{{ form.last_name_ko.errors.0 }}</div>
-                        {% endif %}
+                <div class="mb-4 text-center">
+                    <div class="rounded-circle bg-success text-white d-inline-flex align-items-center justify-content-center mb-2" style="width:60px;height:60px;">
+                        {{ profile.get_korean_name|first|upper }}
                     </div>
+                    <div>{{ user.email }}</div>
+                    <small class="text-muted">가입일: {{ user.date_joined|date:"Y년 m월 d일" }}</small>
                 </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.first_name_ko.id_for_label }}">
-                            이름 (한글)
-                        </label>
-                        {{ form.first_name_ko }}
-                        {% if form.first_name_ko.errors %}
-                            <div class="text-danger small mt-1">{{ form.first_name_ko.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            
-            <div class="form-row">
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.position.id_for_label }}">
-                            직급
-                        </label>
-                        {{ form.position }}
-                        {% if form.position.errors %}
-                            <div class="text-danger small mt-1">{{ form.position.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="form-col">
-                    <div class="form-group">
-                        <label class="form-label" for="{{ form.phone.id_for_label }}">
-                            전화번호
-                        </label>
-                        {{ form.phone }}
-                        {% if form.phone.errors %}
-                            <div class="text-danger small mt-1">{{ form.phone.errors.0 }}</div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
 
-        <!-- 권한 설정 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-shield-alt"></i>
-                권한 설정
-            </h3>
-            
-            <div class="form-group">
-                <label class="form-label">시스템 권한</label>
-                <div class="checkbox-group">
-                    <div class="checkbox-item">
+                <form method="post" id="userEditForm">
+                    {% csrf_token %}
+                    <h5 class="mb-3">기본 정보</h5>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ user_form.first_name.id_for_label }}" class="form-label">이름 (영문)</label>
+                            {{ user_form.first_name }}
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ user_form.last_name.id_for_label }}" class="form-label">성 (영문)</label>
+                            {{ user_form.last_name }}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="{{ user_form.email.id_for_label }}" class="form-label">이메일 <span class="text-danger">*</span></label>
+                        {{ user_form.email }}
+                        {% if user_form.email.errors %}
+                            <div class="text-danger small">{{ user_form.email.errors.0 }}</div>
+                        {% endif %}
+                    </div>
+
+                    <h5 class="mb-3 mt-4">프로필 정보</h5>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ form.last_name_ko.id_for_label }}" class="form-label">성 (한글)</label>
+                            {{ form.last_name_ko }}
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ form.first_name_ko.id_for_label }}" class="form-label">이름 (한글)</label>
+                            {{ form.first_name_ko }}
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ form.position.id_for_label }}" class="form-label">직급</label>
+                            {{ form.position }}
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="{{ form.phone.id_for_label }}" class="form-label">전화번호</label>
+                            {{ form.phone }}
+                        </div>
+                    </div>
+
+                    <h5 class="mb-3 mt-4">권한 설정</h5>
+                    <div class="form-check mb-2">
                         {{ form.is_staff }}
-                        <label for="{{ form.is_staff.id_for_label }}">관리자 권한</label>
+                        <label class="form-check-label" for="{{ form.is_staff.id_for_label }}">관리자 권한</label>
                     </div>
-                    <div class="checkbox-item">
+                    <div class="form-check mb-2">
                         {{ form.is_superuser }}
-                        <label for="{{ form.is_superuser.id_for_label }}">슈퍼유저 권한</label>
+                        <label class="form-check-label" for="{{ form.is_superuser.id_for_label }}">슈퍼유저 권한</label>
                     </div>
-                </div>
-                <div class="help-text">
-                    관리자 권한: 사용자 관리 및 시스템 설정 접근<br>
-                    슈퍼유저 권한: 모든 시스템 기능에 대한 완전한 접근
-                </div>
-            </div>
-            
-            <div class="form-group">
-                <label class="form-label">권한 그룹</label>
-                <div class="checkbox-group">
-                    {% for group in form.groups.field.queryset %}
-                    <div class="checkbox-item">
-                        <input type="checkbox" name="groups" value="{{ group.id }}" 
-                               id="group_{{ group.id }}" 
-                               {% if group in form.groups.initial %}checked{% endif %}
-                               class="form-check-input">
-                        <label for="group_{{ group.id }}">{{ group.name }}</label>
+                    {% if form.groups.field.queryset %}
+                    <label class="form-label mt-3">권한 그룹</label>
+                    <div class="row">
+                        {% for group in form.groups.field.queryset %}
+                            <div class="col-md-4 mb-2">
+                                <div class="form-check">
+                                    <input type="checkbox" name="groups" value="{{ group.id }}" id="group_{{ group.id }}" class="form-check-input" {% if group in user.groups.all %}checked{% endif %}>
+                                    <label class="form-check-label" for="group_{{ group.id }}">{{ group.name }}</label>
+                                </div>
+                            </div>
+                        {% endfor %}
                     </div>
-                    {% endfor %}
-                </div>
-                <div class="help-text">
-                    권한 그룹을 통해 사용자에게 특정 권한을 부여할 수 있습니다.
-                </div>
-            </div>
-        </div>
+                    {% endif %}
 
-        <!-- 팀 설정 -->
-        <div class="form-section">
-            <h3 class="section-title">
-                <i class="fas fa-users"></i>
-                팀 설정
-            </h3>
-            
-            <div class="form-group">
-                <label class="form-label">소속 팀</label>
-                <div class="checkbox-group">
-                    {% for team in form.teams.field.queryset %}
-                    <div class="checkbox-item">
-                        <input type="checkbox" name="teams" value="{{ team.id }}" 
-                               id="team_{{ team.id }}" 
-                               {% if team in form.teams.initial %}checked{% endif %}
-                               class="form-check-input">
-                        <label for="team_{{ team.id }}">{{ team.name }}</label>
+                    <h5 class="mb-3 mt-4">팀 설정</h5>
+                    {% if form.teams.field.queryset %}
+                    <label class="form-label">소속 팀</label>
+                    <div class="row">
+                        {% for team in form.teams.field.queryset %}
+                            <div class="col-md-4 mb-2">
+                                <div class="form-check">
+                                    <input type="checkbox" name="teams" value="{{ team.id }}" id="team_{{ team.id }}" class="form-check-input" {% if team in user.teams.all %}checked{% endif %}>
+                                    <label class="form-check-label" for="team_{{ team.id }}">{{ team.name }}</label>
+                                </div>
+                            </div>
+                        {% endfor %}
                     </div>
-                    {% endfor %}
-                </div>
-                <div class="help-text">
-                    사용자가 소속될 팀을 선택하세요. 여러 팀에 동시 소속이 가능합니다.
-                </div>
-            </div>
-            
-            <!-- 새 팀 생성 -->
-            <div class="team-create-section">
-                <a href="#" class="team-create-toggle" onclick="toggleTeamCreate()">
-                    <i class="fas fa-plus me-2"></i>새 팀 생성하기
-                </a>
-                <div class="team-create-form" id="teamCreateForm">
-                    <div class="form-row">
-                        <div class="form-col">
-                            <input type="text" class="form-control" id="newTeamName" 
-                                   placeholder="팀명을 입력하세요" required>
-                        </div>
-                        <div class="form-col">
-                            <button type="button" class="btn btn-primary" onclick="createTeam()">
-                                팀 생성
-                            </button>
-                        </div>
+                    {% endif %}
+                    <div class="mb-3">
+                        <label for="{{ form.team_role.id_for_label }}" class="form-label">팀 내 역할</label>
+                        {{ form.team_role }}
                     </div>
-                    <div class="form-group mt-2">
-                        <textarea class="form-control" id="newTeamDescription" 
-                                  placeholder="팀 설명 (선택사항)" rows="2"></textarea>
-                    </div>
-                </div>
-            </div>
-        </div>
 
-        <div class="btn-group">
-            <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary">취소</a>
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-2"></i>변경사항 저장
-            </button>
+                    <div class="d-flex justify-content-between">
+                        <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary"><i class="fas fa-arrow-left"></i> 취소</a>
+                        <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> 변경사항 저장</button>
+                    </div>
+                </form>
+            </div>
         </div>
-    </form>
+    </div>
 </div>
-{% endblock %}
-
-{% block extra_js %}
-<script>
-// 폼 유효성 검사
-document.getElementById('userEditForm').addEventListener('submit', function(e) {
-    const email = document.getElementById('{{ user_form.email.id_for_label }}').value.trim();
-    
-    if (!email) {
-        e.preventDefault();
-        alert('이메일은 필수 입력 항목입니다.');
-        return false;
-    }
-    
-    // 이메일 형식 검사
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-        e.preventDefault();
-        alert('올바른 이메일 형식을 입력해주세요.');
-        return false;
-    }
-});
-
-// 체크박스 상호작용 개선
-document.querySelectorAll('.checkbox-item').forEach(item => {
-    item.addEventListener('click', function(e) {
-        if (e.target.type !== 'checkbox') {
-            const checkbox = this.querySelector('input[type="checkbox"]');
-            checkbox.checked = !checkbox.checked;
-        }
-    });
-});
-
-// 슈퍼유저 권한 선택 시 관리자 권한 자동 선택
-document.getElementById('{{ form.is_superuser.id_for_label }}').addEventListener('change', function() {
-    if (this.checked) {
-        document.getElementById('{{ form.is_staff.id_for_label }}').checked = true;
-    }
-});
-
-function toggleTeamCreate() {
-    const form = document.getElementById('teamCreateForm');
-    if (form.style.display === 'none' || form.style.display === '') {
-        form.style.display = 'block';
-    } else {
-        form.style.display = 'none';
-    }
-}
-
-function createTeam() {
-    const name = document.getElementById('newTeamName').value.trim();
-    const description = document.getElementById('newTeamDescription').value.trim();
-    
-    if (!name) {
-        alert('팀명을 입력해주세요.');
-        return;
-    }
-    
-    fetch('{% url "team_create_ajax" %}', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
-        },
-        body: `name=${encodeURIComponent(name)}&description=${encodeURIComponent(description)}`
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            // 새 팀을 체크박스 목록에 추가
-            const checkboxGroup = document.querySelector('.form-section:last-of-type .checkbox-group');
-            const newCheckbox = document.createElement('div');
-            newCheckbox.className = 'checkbox-item';
-            newCheckbox.innerHTML = `
-                <input type="checkbox" name="teams" value="${data.team_id}" 
-                       id="team_${data.team_id}" class="form-check-input" checked>
-                <label for="team_${data.team_id}">${data.team_name}</label>
-            `;
-            checkboxGroup.appendChild(newCheckbox);
-            
-            // 폼 초기화 및 숨기기
-            document.getElementById('newTeamName').value = '';
-            document.getElementById('newTeamDescription').value = '';
-            document.getElementById('teamCreateForm').style.display = 'none';
-            
-            alert(data.message);
-        } else {
-            alert('팀 생성에 실패했습니다: ' + JSON.stringify(data.errors));
-        }
-    })
-    .catch(error => {
-        console.error('Error:', error);
-        alert('팀 생성 중 오류가 발생했습니다.');
-    });
-}
-</script>
 {% endblock %}

--- a/templates/accounts/user_list.html
+++ b/templates/accounts/user_list.html
@@ -1,484 +1,127 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .user-list-container {
-        padding: 20px;
-    }
-    
-    .header-section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .search-filters {
-        background: white;
-        border-radius: 12px;
-        padding: 20px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .filter-row {
-        display: flex;
-        gap: 15px;
-        align-items: end;
-        flex-wrap: wrap;
-    }
-    
-    .filter-group {
-        flex: 1;
-        min-width: 200px;
-    }
-    
-    .filter-label {
-        display: block;
-        margin-bottom: 8px;
-        font-weight: 500;
-        color: #333;
-        font-size: 14px;
-    }
-    
-    .form-control {
-        padding: 12px 16px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        font-size: 14px;
-        line-height: 1.5;
-        transition: all 0.3s ease;
-        background-color: #fff;
-    }
-    
-    .form-control:focus {
-        outline: none;
-        border-color: #03C75A;
-        box-shadow: 0 0 0 3px rgba(3, 199, 90, 0.1);
-        background-color: #fff;
-    }
-    
-    .form-control::placeholder {
-        color: #999;
-        opacity: 1;
-    }
-    
-    select.form-control {
-        cursor: pointer;
-    }
-    
-    .btn-primary {
-        background: linear-gradient(135deg, #03C75A 0%, #029B47 100%);
-        border: none;
-        color: white;
-        padding: 12px 20px;
-        border-radius: 8px;
-        font-weight: 500;
-        font-size: 14px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        line-height: 1;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        border: none;
-        color: white;
-        padding: 12px 20px;
-        border-radius: 8px;
-        font-weight: 500;
-        font-size: 14px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        line-height: 1;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-        transform: translateY(-1px);
-    }
-    
-    .btn-sm {
-        padding: 8px 12px;
-        font-size: 12px;
-        min-width: 36px;
-    }
-    
-    .users-table {
-        background: white;
-        border-radius: 12px;
-        overflow: hidden;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .table {
-        margin: 0;
-    }
-    
-    .table th {
-        background: #f8f9fa;
-        border-bottom: 2px solid #03C75A;
-        font-weight: 600;
-        color: #333;
-        padding: 15px;
-    }
-    
-    .table td {
-        padding: 15px;
-        vertical-align: middle;
-        border-bottom: 1px solid #eee;
-    }
-    
-    .table tbody tr:hover {
-        background-color: #f8f9fa;
-    }
-    
-    .user-avatar {
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #03C75A, #029B47);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-weight: bold;
-        margin-right: 10px;
-    }
-    
-    .user-info {
-        display: flex;
-        align-items: center;
-    }
-    
-    .user-details h6 {
-        margin: 0;
-        font-weight: 600;
-        color: #333;
-    }
-    
-    .user-details small {
-        color: #666;
-    }
-    
-    .badge {
-        padding: 4px 8px;
-        border-radius: 12px;
-        font-size: 11px;
-        font-weight: 500;
-        margin-right: 4px;
-    }
-    
-    .badge-success {
-        background-color: #d4edda;
-        color: #155724;
-    }
-    
-    .badge-warning {
-        background-color: #fff3cd;
-        color: #856404;
-    }
-    
-    .badge-info {
-        background-color: #d1ecf1;
-        color: #0c5460;
-    }
-    
-    .badge-secondary {
-        background-color: #e2e3e5;
-        color: #383d41;
-    }
-    
-    .team-list {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px;
-    }
-    
-    .pagination {
-        justify-content: center;
-        margin-top: 20px;
-    }
-    
-    .page-link {
-        color: #03C75A;
-        border-color: #03C75A;
-    }
-    
-    .page-link:hover {
-        color: #029B47;
-        background-color: rgba(3, 199, 90, 0.1);
-        border-color: #029B47;
-    }
-    
-    .page-item.active .page-link {
-        background-color: #03C75A;
-        border-color: #03C75A;
-    }
-    
-    .empty-state {
-        text-align: center;
-        padding: 60px 20px;
-        color: #666;
-    }
-    
-    .empty-state i {
-        font-size: 48px;
-        color: #ddd;
-        margin-bottom: 20px;
-    }
-    
-    @media (max-width: 768px) {
-        .filter-row {
-            flex-direction: column;
-        }
-        
-        .filter-group {
-            min-width: 100%;
-        }
-        
-        .table-responsive {
-            font-size: 14px;
-        }
-        
-        .user-info {
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        
-        .user-avatar {
-            margin-bottom: 5px;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="user-list-container">
-    <!-- 헤더 -->
-    <div class="header-section">
-        <div class="d-flex justify-content-between align-items-center">
-            <div>
-                <h2 class="mb-2">{{ title }}</h2>
-                <p class="text-muted mb-0">시스템 사용자를 관리합니다.</p>
+<div class="row justify-content-center">
+    <div class="col-md-10">
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="mb-0"><i class="fas fa-users"></i> {{ title }}</h4>
+                <a href="{% url 'user_create' %}" class="btn btn-primary"><i class="fas fa-plus"></i> 새 사용자 생성</a>
             </div>
-            <a href="{% url 'user_create' %}" class="btn btn-primary">
-                <i class="fas fa-plus me-2"></i>새 사용자 생성
-            </a>
-        </div>
-    </div>
-
-    <!-- 검색 및 필터 -->
-    <div class="search-filters">
-        <form method="get" class="filter-form">
-            <div class="filter-row">
-                <div class="filter-group">
-                    <label class="filter-label">검색</label>
-                    <input type="text" name="search" class="form-control" 
-                           placeholder="이름, ID, 이메일로 검색" 
-                           value="{{ search_query }}">
-                </div>
-                <div class="filter-group">
-                    <label class="filter-label">팀</label>
-                    <select name="team" class="form-control">
-                        <option value="">전체 팀</option>
-                        {% for team in teams %}
-                        <option value="{{ team.id }}" {% if team_filter == team.id|stringformat:"s" %}selected{% endif %}>
-                            {{ team.name }}
-                        </option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="filter-group">
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-search me-2"></i>검색
-                    </button>
-                    <a href="{% url 'user_list' %}" class="btn btn-secondary ms-2">
-                        <i class="fas fa-times me-2"></i>초기화
-                    </a>
-                </div>
-            </div>
-        </form>
-    </div>
-
-    <!-- 사용자 목록 -->
-    <div class="users-table">
-        {% if page_obj %}
-        <div class="table-responsive">
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>사용자</th>
-                        <th>팀/직급</th>
-                        <th>소속 팀</th>
-                        <th>권한</th>
-                        <th>가입일</th>
-                        <th>작업</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for user in page_obj %}
-                    <tr>
-                        <td>
-                            <div class="user-info">
-                                <div class="user-avatar">
-                                    {{ user.profile.get_korean_name|first|upper }}
-                                </div>
-                                <div class="user-details">
-                                    <h6>{{ user.profile.display_name }}</h6>
-                                    <small>{{ user.email }}</small>
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            {% if user.profile.primary_team %}
-                                <div>{{ user.profile.primary_team.name }}</div>
-                            {% endif %}
-                            {% if user.profile.position %}
-                                <small class="text-muted">{{ user.profile.position }}</small>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div class="team-list">
-                                {% for team in user.teams.all %}
-                                    <span class="badge badge-info">{{ team.name }}</span>
-                                {% empty %}
-                                    <span class="text-muted">-</span>
-                                {% endfor %}
-                            </div>
-                        </td>
-                        <td>
-                            {% if user.is_superuser %}
-                                <span class="badge badge-warning">슈퍼유저</span>
-                            {% elif user.is_staff %}
-                                <span class="badge badge-success">관리자</span>
-                            {% else %}
-                                <span class="badge badge-secondary">일반사용자</span>
-                            {% endif %}
-                            
-                            {% for group in user.groups.all %}
-                                <span class="badge badge-info">{{ group.name }}</span>
+            <div class="card-body">
+                <form method="get" class="row g-2 mb-4">
+                    <div class="col-md-4">
+                        <input type="text" name="search" value="{{ search_query }}" placeholder="검색" class="form-control">
+                    </div>
+                    <div class="col-md-3">
+                        <select name="team" class="form-control">
+                            <option value="">전체 팀</option>
+                            {% for team in teams %}
+                            <option value="{{ team.id }}" {% if team_filter == team.id|stringformat:'s' %}selected{% endif %}>{{ team.name }}</option>
                             {% endfor %}
-                        </td>
-                        <td>
-                            <small>{{ user.date_joined|date:"Y-m-d" }}</small>
-                        </td>
-                        <td>
-                            <div class="btn-group" role="group">
-                                <a href="{% url 'user_detail' user.id %}" 
-                                   class="btn btn-sm btn-secondary" title="상세보기">
-                                    <i class="fas fa-eye"></i>
-                                </a>
-                                <a href="{% url 'user_edit' user.id %}" 
-                                   class="btn btn-sm btn-primary" title="수정">
-                                    <i class="fas fa-edit"></i>
-                                </a>
-                                <a href="{% url 'user_team_manage' user.id %}" 
-                                   class="btn btn-sm btn-info" title="팀 관리">
-                                    <i class="fas fa-users"></i>
-                                </a>
-                                {% if user != request.user %}
-                                <a href="{% url 'user_delete' user.id %}" 
-                                   class="btn btn-sm btn-danger" title="삭제"
-                                   onclick="return confirm('정말로 이 사용자를 삭제하시겠습니까?')">
-                                    <i class="fas fa-trash"></i>
-                                </a>
-                                {% endif %}
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                        </select>
+                    </div>
+                    <div class="col-auto">
+                        <button type="submit" class="btn btn-primary"><i class="fas fa-search"></i> 검색</button>
+                    </div>
+                    <div class="col-auto">
+                        <a href="{% url 'user_list' %}" class="btn btn-secondary"><i class="fas fa-times"></i> 초기화</a>
+                    </div>
+                </form>
 
-        <!-- 페이지네이션 -->
-        {% if page_obj.has_other_pages %}
-        <nav aria-label="사용자 목록 페이지네이션">
-            <ul class="pagination">
-                {% if page_obj.has_previous %}
-                    <li class="page-item">
-                        <a class="page-link" href="?page=1{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">
-                            <i class="fas fa-angle-double-left"></i>
-                        </a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">
-                            <i class="fas fa-angle-left"></i>
-                        </a>
-                    </li>
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle text-center">
+                        <thead>
+                            <tr>
+                                <th>사용자</th>
+                                <th>팀/직급</th>
+                                <th>소속 팀</th>
+                                <th>권한</th>
+                                <th>가입일</th>
+                                <th>작업</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for user in page_obj %}
+                            <tr>
+                                <td class="text-start">
+                                    <div class="d-flex align-items-center">
+                                        <div class="rounded-circle bg-success text-white d-flex align-items-center justify-content-center me-2" style="width:40px;height:40px;">
+                                            {{ user.profile.get_korean_name|first|upper }}
+                                        </div>
+                                        <div>
+                                            <div>{{ user.profile.display_name }}</div>
+                                            <small class="text-muted">{{ user.email }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    {% if user.profile.primary_team %}{{ user.profile.primary_team.name }}{% endif %}
+                                    {% if user.profile.position %}<div class="text-muted small">{{ user.profile.position }}</div>{% endif %}
+                                </td>
+                                <td>
+                                    {% for team in user.teams.all %}
+                                        <span class="badge bg-info text-dark">{{ team.name }}</span>
+                                    {% empty %}
+                                        <span class="text-muted">-</span>
+                                    {% endfor %}
+                                </td>
+                                <td>
+                                    {% if user.is_superuser %}
+                                        <span class="badge bg-warning text-dark">슈퍼유저</span>
+                                    {% elif user.is_staff %}
+                                        <span class="badge bg-success">관리자</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">일반사용자</span>
+                                    {% endif %}
+                                    {% for group in user.groups.all %}
+                                        <span class="badge bg-info text-dark">{{ group.name }}</span>
+                                    {% endfor %}
+                                </td>
+                                <td><small>{{ user.date_joined|date:"Y-m-d" }}</small></td>
+                                <td>
+                                    <div class="btn-group" role="group">
+                                        <a href="{% url 'user_detail' user.id %}" class="btn btn-sm btn-secondary" title="상세보기"><i class="fas fa-eye"></i></a>
+                                        <a href="{% url 'user_edit' user.id %}" class="btn btn-sm btn-primary" title="수정"><i class="fas fa-edit"></i></a>
+                                        <a href="{% url 'user_team_manage' user.id %}" class="btn btn-sm btn-info" title="팀 관리"><i class="fas fa-users"></i></a>
+                                        {% if user != request.user %}
+                                            <a href="{% url 'user_delete' user.id %}" class="btn btn-sm btn-danger" onclick="return confirm('정말로 이 사용자를 삭제하시겠습니까?')" title="삭제"><i class="fas fa-trash"></i></a>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                        {% empty %}
+                            <tr><td colspan="6" class="text-center text-muted">사용자가 없습니다.</td></tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                {% if page_obj.has_other_pages %}
+                <nav class="mt-3" aria-label="pagination">
+                    <ul class="pagination justify-content-center">
+                        {% if page_obj.has_previous %}
+                            <li class="page-item"><a class="page-link" href="?page=1{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">&laquo;</a></li>
+                            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">&lt;</a></li>
+                        {% endif %}
+                        {% for num in page_obj.paginator.page_range %}
+                            {% if page_obj.number == num %}
+                                <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+                            {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+                                <li class="page-item"><a class="page-link" href="?page={{ num }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">{{ num }}</a></li>
+                            {% endif %}
+                        {% endfor %}
+                        {% if page_obj.has_next %}
+                            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">&gt;</a></li>
+                            <li class="page-item"><a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">&raquo;</a></li>
+                        {% endif %}
+                    </ul>
+                </nav>
                 {% endif %}
-
-                {% for num in page_obj.paginator.page_range %}
-                    {% if page_obj.number == num %}
-                        <li class="page-item active">
-                            <span class="page-link">{{ num }}</span>
-                        </li>
-                    {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-                        <li class="page-item">
-                            <a class="page-link" href="?page={{ num }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">{{ num }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-
-                {% if page_obj.has_next %}
-                    <li class="page-item">
-                        <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">
-                            <i class="fas fa-angle-right"></i>
-                        </a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if search_query %}&search={{ search_query }}{% endif %}{% if team_filter %}&team={{ team_filter }}{% endif %}">
-                            <i class="fas fa-angle-double-right"></i>
-                        </a>
-                    </li>
-                {% endif %}
-            </ul>
-        </nav>
-        {% endif %}
-
-        {% else %}
-        <div class="empty-state">
-            <i class="fas fa-users"></i>
-            <h4>사용자가 없습니다</h4>
-            <p>검색 조건을 변경하거나 새 사용자를 생성해보세요.</p>
-            <a href="{% url 'user_create' %}" class="btn btn-primary">
-                <i class="fas fa-plus me-2"></i>새 사용자 생성
-            </a>
+            </div>
         </div>
-        {% endif %}
     </div>
 </div>
-{% endblock %}
-
-{% block extra_js %}
-<script>
-// 검색 폼 자동 제출 (엔터키)
-document.querySelector('input[name="search"]').addEventListener('keypress', function(e) {
-    if (e.key === 'Enter') {
-        this.form.submit();
-    }
-});
-</script>
 {% endblock %}

--- a/templates/accounts/user_team_manage.html
+++ b/templates/accounts/user_team_manage.html
@@ -1,452 +1,94 @@
 {% extends 'base.html' %}
-{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block extra_css %}
-<style>
-    .team-manage-container {
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 20px;
-    }
-    
-    .header-section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .user-info {
-        display: flex;
-        align-items: center;
-        gap: 15px;
-        margin-bottom: 20px;
-    }
-    
-    .user-avatar {
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, #03C75A, #029B47);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-size: 24px;
-        font-weight: bold;
-    }
-    
-    .user-details h3 {
-        margin: 0;
-        color: #333;
-        font-weight: 600;
-    }
-    
-    .user-details p {
-        margin: 5px 0 0;
-        color: #666;
-    }
-    
-    .section {
-        background: white;
-        border-radius: 12px;
-        padding: 24px;
-        margin-bottom: 20px;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .section-title {
-        color: #333;
-        font-size: 18px;
-        font-weight: 600;
-        margin-bottom: 20px;
-        padding-bottom: 10px;
-        border-bottom: 2px solid #03C75A;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-    }
-    
-    .team-card {
-        border: 1px solid #eee;
-        border-radius: 8px;
-        padding: 20px;
-        margin-bottom: 15px;
-        transition: all 0.3s;
-        position: relative;
-    }
-    
-    .team-card:hover {
-        border-color: #03C75A;
-        box-shadow: 0 2px 8px rgba(3, 199, 90, 0.1);
-    }
-    
-    .team-header {
-        display: flex;
-        justify-content: between;
-        align-items: flex-start;
-        margin-bottom: 10px;
-    }
-    
-    .team-name {
-        font-weight: 600;
-        color: #333;
-        font-size: 16px;
-        margin-bottom: 5px;
-    }
-    
-    .team-description {
-        color: #666;
-        font-size: 14px;
-        margin-bottom: 10px;
-    }
-    
-    .team-meta {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 10px;
-    }
-    
-    .team-role {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
-    
-    .team-joined {
-        font-size: 12px;
-        color: #999;
-    }
-    
-    .badge {
-        padding: 4px 8px;
-        border-radius: 12px;
-        font-size: 11px;
-        font-weight: 500;
-    }
-    
-    .badge-warning {
-        background-color: #fff3cd;
-        color: #856404;
-    }
-    
-    .badge-success {
-        background-color: #d4edda;
-        color: #155724;
-    }
-    
-    .badge-info {
-        background-color: #d1ecf1;
-        color: #0c5460;
-    }
-    
-    .remove-btn {
-        position: absolute;
-        top: 15px;
-        right: 15px;
-        background: #dc3545;
-        color: white;
-        border: none;
-        border-radius: 50%;
-        width: 30px;
-        height: 30px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        cursor: pointer;
-        transition: all 0.3s;
-        font-size: 12px;
-    }
-    
-    .remove-btn:hover {
-        background: #c82333;
-        transform: scale(1.1);
-    }
-    
-    .add-team-form {
-        background: #f8f9fa;
-        border: 2px dashed #03C75A;
-        border-radius: 8px;
-        padding: 20px;
-        margin-bottom: 20px;
-    }
-    
-    .form-row {
-        display: flex;
-        gap: 15px;
-        align-items: end;
-        flex-wrap: wrap;
-    }
-    
-    .form-group {
-        flex: 1;
-        min-width: 200px;
-    }
-    
-    .form-label {
-        display: block;
-        margin-bottom: 5px;
-        font-weight: 500;
-        color: #333;
-    }
-    
-    .form-control {
-        width: 100%;
-        padding: 8px 12px;
-        border: 1px solid #ddd;
-        border-radius: 6px;
-        font-size: 14px;
-        transition: border-color 0.3s;
-    }
-    
-    .form-control:focus {
-        outline: none;
-        border-color: #03C75A;
-        box-shadow: 0 0 0 2px rgba(3, 199, 90, 0.2);
-    }
-    
-    .btn {
-        padding: 8px 16px;
-        border-radius: 6px;
-        font-weight: 500;
-        cursor: pointer;
-        transition: all 0.3s;
-        text-decoration: none;
-        display: inline-block;
-        border: none;
-    }
-    
-    .btn-primary {
-        background: linear-gradient(135deg, #03C75A 0%, #029B47 100%);
-        color: white;
-    }
-    
-    .btn-primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(3, 199, 90, 0.3);
-        color: white;
-        text-decoration: none;
-    }
-    
-    .btn-secondary {
-        background: #6c757d;
-        color: white;
-    }
-    
-    .btn-secondary:hover {
-        background: #5a6268;
-        color: white;
-        text-decoration: none;
-    }
-    
-    .empty-state {
-        text-align: center;
-        padding: 40px 20px;
-        color: #666;
-    }
-    
-    .empty-state i {
-        font-size: 32px;
-        color: #ddd;
-        margin-bottom: 15px;
-    }
-    
-    .btn-group {
-        display: flex;
-        gap: 10px;
-        justify-content: flex-end;
-        margin-top: 30px;
-    }
-    
-    @media (max-width: 768px) {
-        .form-row {
-            flex-direction: column;
-        }
-        
-        .form-group {
-            min-width: 100%;
-        }
-        
-        .team-meta {
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        
-        .remove-btn {
-            position: static;
-            margin-top: 10px;
-            width: auto;
-            height: auto;
-            padding: 5px 10px;
-            border-radius: 4px;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="team-manage-container">
-    <!-- 헤더 -->
-    <div class="header-section">
-        <div class="user-info">
-            <div class="user-avatar">
-                {{ profile.get_korean_name|first|upper }}
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card mb-4">
+            <div class="card-header">
+                <h4 class="mb-0"><i class="fas fa-users"></i> 팀 관리</h4>
             </div>
-            <div class="user-details">
-                <h3>{{ profile.display_name }}</h3>
-                <p>{{ user.email }}</p>
-            </div>
-        </div>
-        <h2 class="mb-0">팀 관리</h2>
-        <p class="text-muted mb-0">사용자의 팀 소속을 관리합니다.</p>
-    </div>
-
-    {% if messages %}
-        {% for message in messages %}
-            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-        {% endfor %}
-    {% endif %}
-
-    <!-- 팀 추가 -->
-    {% if available_teams %}
-    <div class="section">
-        <h3 class="section-title">
-            <i class="fas fa-plus"></i>
-            팀 추가
-        </h3>
-        
-        <form method="post" class="add-team-form">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="add_team">
-            
-            <div class="form-row">
-                <div class="form-group">
-                    <label class="form-label">팀 선택</label>
-                    <select name="team_id" class="form-control" required>
-                        <option value="">팀을 선택하세요</option>
-                        {% for team in available_teams %}
-                        <option value="{{ team.id }}">{{ team.name }}</option>
-                        {% endfor %}
-                    </select>
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-4">
+                    <div class="rounded-circle bg-success text-white d-flex align-items-center justify-content-center me-3" style="width:60px;height:60px;">
+                        {{ profile.get_korean_name|first|upper }}
+                    </div>
+                    <div>
+                        <h5 class="mb-1">{{ profile.display_name }}</h5>
+                        <small class="text-muted">{{ user.email }}</small>
+                    </div>
                 </div>
-                <div class="form-group">
-                    <label class="form-label">역할</label>
-                    <select name="role" class="form-control">
-                        {% for value, label in role_choices %}
-                        <option value="{{ value }}">{{ label }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="form-group">
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-plus me-2"></i>팀 추가
-                    </button>
-                </div>
-            </div>
-        </form>
-    </div>
-    {% endif %}
 
-    <!-- 현재 소속 팀 -->
-    <div class="section">
-        <h3 class="section-title">
-            <i class="fas fa-users"></i>
-            현재 소속 팀 ({{ current_memberships.count }}개)
-        </h3>
-        
-        {% if current_memberships %}
-            {% for membership in current_memberships %}
-            <div class="team-card">
-                <button type="button" class="remove-btn" 
-                        onclick="removeTeam({{ membership.id }}, '{{ membership.team.name }}')"
-                        title="팀에서 제거">
-                    <i class="fas fa-times"></i>
-                </button>
-                
-                <div class="team-name">{{ membership.team.name }}</div>
-                
-                {% if membership.team.description %}
-                <div class="team-description">{{ membership.team.description }}</div>
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endfor %}
                 {% endif %}
-                
-                <div class="team-meta">
-                    <div class="team-role">
-                        <span>역할:</span>
-                        {% if membership.role == 'leader' %}
-                            <span class="badge badge-warning">팀장</span>
-                        {% elif membership.role == 'admin' %}
-                            <span class="badge badge-success">관리자</span>
-                        {% else %}
-                            <span class="badge badge-info">멤버</span>
-                        {% endif %}
-                    </div>
-                    <div class="team-joined">
-                        {{ membership.joined_at|date:"Y년 m월 d일" }} 가입
-                    </div>
-                </div>
-            </div>
-            {% endfor %}
-        {% else %}
-            <div class="empty-state">
-                <i class="fas fa-users"></i>
-                <h4>소속된 팀이 없습니다</h4>
-                <p>위에서 팀을 추가해보세요.</p>
-            </div>
-        {% endif %}
-    </div>
 
-    <!-- 버튼 그룹 -->
-    <div class="btn-group">
-        <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary">
-            <i class="fas fa-arrow-left me-2"></i>사용자 상세로
-        </a>
-        <a href="{% url 'user_list' %}" class="btn btn-secondary">
-            <i class="fas fa-list me-2"></i>사용자 목록
-        </a>
-    </div>
-</div>
-
-<!-- 팀 제거 확인 모달 -->
-<div class="modal fade" id="removeTeamModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">팀 제거 확인</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <p><strong id="removeTeamName"></strong> 팀에서 이 사용자를 제거하시겠습니까?</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                <form method="post" style="display: inline;">
+                {% if available_teams %}
+                <form method="post" class="mb-4 row g-2">
                     {% csrf_token %}
-                    <input type="hidden" name="action" value="remove_team">
-                    <input type="hidden" name="membership_id" id="removeMembershipId">
-                    <button type="submit" class="btn btn-danger">제거</button>
+                    <input type="hidden" name="action" value="add_team">
+                    <div class="col-md-5">
+                        <select name="team_id" class="form-control" required>
+                            <option value="">팀 선택</option>
+                            {% for team in available_teams %}
+                                <option value="{{ team.id }}">{{ team.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <select name="role" class="form-control">
+                            {% for value, label in role_choices %}
+                                <option value="{{ value }}">{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-auto">
+                        <button type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> 팀 추가</button>
+                    </div>
                 </form>
+                {% endif %}
+
+                <h5 class="mb-3">현재 소속 팀 ({{ current_memberships.count }})</h5>
+                {% if current_memberships %}
+                    <ul class="list-group mb-4">
+                        {% for membership in current_memberships %}
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong>{{ membership.team.name }}</strong>
+                                    {% if membership.role == 'leader' %}
+                                        <span class="badge bg-warning text-dark ms-2">팀장</span>
+                                    {% elif membership.role == 'admin' %}
+                                        <span class="badge bg-success ms-2">관리자</span>
+                                    {% else %}
+                                        <span class="badge bg-info text-dark ms-2">멤버</span>
+                                    {% endif %}
+                                    <div class="text-muted small">{{ membership.joined_at|date:"Y년 m월 d일" }} 가입</div>
+                                </div>
+                                <form method="post" class="m-0">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="action" value="remove_team">
+                                    <input type="hidden" name="membership_id" value="{{ membership.id }}">
+                                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('해당 팀에서 제거하시겠습니까?')"><i class="fas fa-times"></i></button>
+                                </form>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted">소속된 팀이 없습니다.</p>
+                {% endif %}
+
+                <div class="d-flex justify-content-between">
+                    <a href="{% url 'user_detail' user.id %}" class="btn btn-secondary"><i class="fas fa-arrow-left"></i> 사용자 상세로</a>
+                    <a href="{% url 'user_list' %}" class="btn btn-secondary"><i class="fas fa-list"></i> 사용자 목록</a>
+                </div>
             </div>
         </div>
     </div>
 </div>
-{% endblock %}
-
-{% block extra_js %}
-<script>
-function removeTeam(membershipId, teamName) {
-    document.getElementById('removeMembershipId').value = membershipId;
-    document.getElementById('removeTeamName').textContent = teamName;
-    
-    const modal = new bootstrap.Modal(document.getElementById('removeTeamModal'));
-    modal.show();
-}
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- switch account templates under `templates/accounts` to card-style layouts
- use Bootstrap formatting similar to `profile_edit.html` and reports

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6879ae9ed164832f981ce2aa79aba28d